### PR TITLE
fix(event): use correct attribute for claim method

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -270,7 +270,7 @@ pub fn claim(
             USER_POOL.remove(deps.storage, user_pool_id.clone());
 
             Ok(Response::new()
-                .add_attribute("method", "set_refundable")
+                .add_attribute("method", "claim")
                 .add_message(CosmosMsg::Bank(BankMsg::Send {
                     to_address: info.sender.to_string(),
                     amount: vec![Coin { denom: bond_denom.clone(), amount: user_pool }],


### PR DESCRIPTION
The `claim` function was emitting an event with attribute `method: set_refundable` which confused me during testing. It seems like a copy+paste error and the correct attribute should be `method: claim`.