### PR TITLE
fix(claim): allow claiming with zero fees

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -255,7 +255,9 @@ pub fn claim(
             }
         }
         None => {
-            return Err(StdError::generic_err(format!("You must attach {}{} to claim reward", claim_reward_fee, bond_denom)));
+            if claim_reward_fee != Uint128::zero() {
+                return Err(StdError::generic_err(format!("You must attach {}{} to claim reward", claim_reward_fee, bond_denom)));
+            }
         }
     }
 


### PR DESCRIPTION
When the `claim_reward_fee` is set to zero, there would be an error saying that the user must attach 0"token" to claim, which is impossible because if you set `--amount 0"token"` in the CLI, it gets parsed out and `MessageInfo.funds` is empty, so it leads to an impossibility scenario.

The fix is to check if the `MessageInfo.funds` is empty AND if the `claim_reward_fee` is zero, to just pass through. Only error if the `claim_reward_fee` is non-zero. 